### PR TITLE
GrabNICMTU(): ignore "bonding_masters" in /sys/class/net

### DIFF
--- a/src/exporter/hardwareprofile.go
+++ b/src/exporter/hardwareprofile.go
@@ -188,6 +188,8 @@ func GrabNICMTU() {
 			continue
 		} else if strings.Contains(outputString[i], "lo") {
 			continue
+		} else if strings.Contains(outputString[i], "bonding_masters") {
+			continue
 		}
 
 		// grab the


### PR DESCRIPTION
file bonding_masters is automatically created when dealing with bonded interfaces, and this is making the exporter to abort execution.